### PR TITLE
name should be in between ""

### DIFF
--- a/php-build/include/sheet/attachEvent.js
+++ b/php-build/include/sheet/attachEvent.js
@@ -57,7 +57,7 @@ sheet.fx.attachEvent = function(){
             currentCell.setValue(newVal);
 
             currentSheet.el
-                        .find('[name='+currentCell.el.attr('name')+']')
+                        .find('[name="'+currentCell.el.attr('name')+'"]')
                         .not(currentCell.el)
                         .each(function(){
                             var radioBox     = $(this),


### PR DESCRIPTION
If radio name contains a bracket like ex: "options[1]" jquery would fire an error.
Per jquery documentation name should be in between "" 
http://api.jquery.com/category/selectors/